### PR TITLE
fix(readme): buildSDK name tipo;

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage
 newrelic_agent.log
 yarn-error.log
 cache
+.idea

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ npm install @balmy/sdk
 ### 👷🏽‍♀️ Building the SDK
 
 ```javascript
-import { buildSdk } from "@balmy/sdk";
+import { buildSDK } from "@balmy/sdk";
 
-const sdk = buildSdk(config);
+const sdk = buildSDK(config);
 ```
 
 ### ⚖️ Getting balance for multiple tokens on several chains


### PR DESCRIPTION
When I copy/pasted the code from README.md I got the next error:
TS2724: "@balmy/ sdk" has no exported member named buildSdk. Did you mean buildSDK?

The issue is the case of the buildSDK identifier. Last three letters should be in upper case. I fix readme to avoid confusion among newcomers.